### PR TITLE
feat: 작가 상세 페이지에 뒤로 가기 네비게이션 추가

### DIFF
--- a/src/assets/blackicon.svg
+++ b/src/assets/blackicon.svg
@@ -1,0 +1,3 @@
+<svg width="20" height="21" viewBox="0 0 20 21" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M14.1665 2.16797L5.83317 10.5013L14.1665 18.8346" stroke="white" stroke-width="1.25"/>
+</svg>

--- a/src/components/Layouts/BackNavigate.tsx
+++ b/src/components/Layouts/BackNavigate.tsx
@@ -1,0 +1,56 @@
+import { useNavigate } from "react-router-dom";
+import { cn } from "../../utils/classname";
+
+export interface BackNavigateProps {
+  pathname: string;
+  text: string;
+  variant?: "primary" | "secondary";
+  className?: string;
+}
+
+const BackNavigate: React.FC<BackNavigateProps> = ({
+  pathname,
+  text,
+  variant = "primary",
+  className,
+}) => {
+  const navigate = useNavigate();
+
+  const variantClasses = {
+    primary: "bg-stone-800/60 text-white hover:bg-stone-900/60",
+    secondary:
+      "bg-[linear-gradient(90deg,#EAEBED_0%,#F4F5F6_28.37%)] text-zinc-900 hover:bg-gray-300",
+  };
+
+  return (
+    <div
+      className={cn(
+        variantClasses[variant],
+        "w-full flex px-20 py-6",
+        className
+      )}
+    >
+      <button
+        className="flex items-center gap-2 font-semibold text-xl cursor-pointer"
+        onClick={() => navigate(pathname)}
+      >
+        <svg
+          width="20"
+          height="21"
+          viewBox="0 0 20 21"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M14.1665 2.16797L5.83317 10.5013L14.1665 18.8346"
+            stroke={variant === "primary" ? "white" : "#1D1E20"}
+            stroke-width="1.25"
+          />
+        </svg>
+        {text}
+      </button>
+    </div>
+  );
+};
+
+export default BackNavigate;

--- a/src/pages/ArtistDetailPage.tsx
+++ b/src/pages/ArtistDetailPage.tsx
@@ -8,6 +8,7 @@ import DisplayEntry from "../components/Profile/DisplayEntry";
 import ArtworkCard from "../components/ArtworkCard";
 import TagFilterBar from "../components/Profile/TagFilterBar";
 import { useParams } from "react-router-dom";
+import BackNavigate from "../components/Layouts/BackNavigate";
 
 const artistTabs = [
   { id: "artistNote", label: "작가노트" },
@@ -109,8 +110,20 @@ const noContentMessages = {
   },
 };
 
+interface ArtistData {
+  role: string;
+  nickName: string;
+  phoneNumber: string;
+  email: string;
+  introduction: string;
+  birthdate: string;
+  education: string;
+  followers: number;
+  following: number;
+}
+
 // Mock 작가 데이터 (실제로는 API에서 가져와야 함)
-const mockArtistData: Record<string, any> = {
+const mockArtistData: Record<string, ArtistData> = {
   "1": {
     role: "작가",
     nickName: "김아티스트",
@@ -194,6 +207,12 @@ const ArtistDetailPage: React.FC = () => {
     <>
       <Header />
       <div className="relative">
+        <BackNavigate
+          pathname="/note"
+          text="작가노트"
+          variant="primary"
+          className="absolute z-10"
+        />
         <BannerControl isMyProfile={isMyProfile} />
         <ProfileCard
           role={artistData.role}


### PR DESCRIPTION
- ArtistDetailPage에 BackNavigate 컴포넌트를 추가하여 사용자 경험 향상
- mockArtistData의 타입을 Record<string, ArtistData>로 변경하여 데이터 구조 명확화
- 작가 상세 페이지의 레이아웃 개선을 위한 BackNavigate 스타일 추가

### 📌 PR 제목 (제목 작성 후 해당 부분은 내용에서 지워주세요!)

[Feat/#이슈 번호] " pr message "
(예시 : [Feat/#1] "로그인 기능 추가")   

### 📌 관련 이슈번호

(Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힌다)

- Closes #33 

### 📌 PR 유형

어떤 변경 사항이 있나요?

- [ ] 새 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 리팩토링

### 📌 PR 요약

해당 PR을 간단하게 요약해 주세요

### 📌 작업 세부 내용

1. page navigate 컴포넌트 제작.
2. 지금 작가 노트 상세 페이지에 absolute로 작성해서 넣음.
3. 다른 데에서 쓸것도 만들어놓음(secondary variant 사용하면 됨)

### 📸 스크린샷 (선택)

### 🔗 참고 자료

​
