### PR TITLE
feat: 작가 노트 및 태그 관련 API 추가 및 헤더 메뉴 활성화 기능 개선

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -1,0 +1,198 @@
+# 🚀 ARTORY 웹 애플리케이션 배포 가이드
+
+## 📋 배포 전 준비사항
+
+### 1. 환경 변수 설정
+
+다음 환경 변수들을 설정해야 합니다:
+
+```bash
+# Google OAuth 설정
+VITE_GOOGLE_CLIENT_ID=your_google_client_id_here
+VITE_GOOGLE_CLIENT_SECRET=your_google_client_secret_here
+
+# API 서버 설정
+VITE_API_BASE_URL=http://13.209.252.181:8080
+
+# 리다이렉트 URI (도메인에 따라 변경)
+VITE_GOOGLE_REDIRECT_URI=https://your-domain.vercel.app/auth/google/callback
+```
+
+### 2. Google OAuth 설정 업데이트
+
+Google Cloud Console에서 승인된 리디렉션 URI에 프로덕션 도메인 추가:
+
+- `https://your-domain.vercel.app/auth/google/callback`
+
+---
+
+## 🌟 추천 배포 방법: Vercel
+
+### 장점
+
+- React/Vite 프로젝트 최적화
+- 자동 HTTPS, CDN, 무료 SSL
+- GitHub 연동 자동 배포
+- 환경 변수 관리 용이
+- 무료 플랜으로 충분
+
+### 배포 단계
+
+#### 1. Vercel 계정 생성 및 연결
+
+```bash
+# Vercel CLI 설치
+npm i -g vercel
+
+# 로그인
+vercel login
+```
+
+#### 2. 프로젝트 배포
+
+```bash
+# 프로젝트 루트에서 실행
+vercel
+
+# 또는 GitHub 연동하여 자동 배포 설정
+```
+
+#### 3. 환경 변수 설정
+
+Vercel 대시보드에서 환경 변수 추가:
+
+- Settings > Environment Variables
+- 위의 환경 변수들을 모두 추가
+
+#### 4. 도메인 설정 (선택사항)
+
+- Vercel 대시보드에서 커스텀 도메인 추가 가능
+
+---
+
+## 🔧 기타 배포 옵션
+
+### 2. Netlify
+
+```bash
+# Netlify CLI 설치
+npm install -g netlify-cli
+
+# 빌드 및 배포
+npm run build
+netlify deploy --prod --dir=dist
+```
+
+### 3. AWS S3 + CloudFront
+
+```bash
+# 빌드
+npm run build
+
+# AWS CLI로 S3에 업로드
+aws s3 sync dist/ s3://your-bucket-name --delete
+```
+
+### 4. GitHub Pages
+
+```bash
+# gh-pages 패키지 설치
+npm install --save-dev gh-pages
+
+# package.json에 스크립트 추가
+"homepage": "https://username.github.io/repository-name",
+"predeploy": "npm run build",
+"deploy": "gh-pages -d dist"
+
+# 배포
+npm run deploy
+```
+
+---
+
+## ⚙️ 배포 후 확인사항
+
+### 1. 기능 테스트
+
+- [ ] 로그인/로그아웃 기능
+- [ ] API 통신 정상 동작
+- [ ] 라우팅 정상 동작
+- [ ] 반응형 디자인 확인
+
+### 2. 성능 최적화
+
+- [ ] Lighthouse 점수 확인
+- [ ] 이미지 최적화
+- [ ] 번들 크기 최적화
+
+### 3. SEO 및 메타태그
+
+- [ ] Open Graph 태그 설정
+- [ ] 파비콘 설정
+- [ ] 메타 디스크립션 설정
+
+---
+
+## 🔒 보안 고려사항
+
+1. **환경 변수 관리**
+
+   - 민감한 정보는 반드시 환경 변수로 관리
+   - `.env` 파일은 절대 커밋하지 않기
+
+2. **HTTPS 강제**
+
+   - 프로덕션에서는 HTTPS 사용 필수
+   - HTTP 요청을 HTTPS로 리다이렉트
+
+3. **CORS 설정**
+   - API 서버에서 적절한 CORS 정책 설정
+   - 신뢰할 수 있는 도메인만 허용
+
+---
+
+## 📈 모니터링 및 분석
+
+### 추천 도구
+
+- **Vercel Analytics**: 기본 성능 분석
+- **Google Analytics**: 사용자 행동 분석
+- **Sentry**: 에러 모니터링
+- **LogRocket**: 사용자 세션 녹화
+
+### 설정 방법
+
+```bash
+# Sentry 설치 (에러 모니터링)
+npm install @sentry/react @sentry/tracing
+
+# Google Analytics 설치
+npm install react-ga4
+```
+
+---
+
+## 🚨 문제 해결
+
+### 자주 발생하는 문제
+
+1. **라우팅 404 에러**
+
+   - SPA 라우팅을 위한 fallback 설정 필요
+   - `vercel.json`에 rewrites 설정됨
+
+2. **환경 변수 인식 안됨**
+
+   - `VITE_` 접두사 확인
+   - 배포 플랫폼에서 환경 변수 설정 확인
+
+3. **API 통신 오류**
+
+   - CORS 설정 확인
+   - API 서버 상태 확인
+   - 네트워크 연결 확인
+
+4. **Google OAuth 오류**
+   - 리다이렉트 URI 설정 확인
+   - 클라이언트 ID 정확성 확인
+   - 도메인 승인 상태 확인

--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
     "lint": "eslint .",
     "preview": "vite preview",
     "storybook": "storybook dev -p 6006",
-    "build-storybook": "storybook build"
+    "build-storybook": "storybook build",
+    "deploy:vercel": "vercel --prod",
+    "deploy:netlify": "netlify deploy --prod --dir=dist"
   },
   "dependencies": {
     "@tailwindcss/vite": "^4.1.11",

--- a/src/apis/artistNote.ts
+++ b/src/apis/artistNote.ts
@@ -1,0 +1,44 @@
+import axios from "axios";
+import type {
+  ArtistNoteListParams,
+  ArtistNoteApiResponse,
+} from "../types/artistNote";
+
+// 작가 노트 API 객체
+export const artistNoteApi = {
+  // 작가 노트 리스트 조회 API
+  async getArtistNoteList(
+    params: ArtistNoteListParams
+  ): Promise<ArtistNoteApiResponse> {
+    console.log("🎨 작가 노트 리스트 조회 시작:", params);
+
+    // 인터셉터를 우회하여 직접 axios 사용
+    const baseURL = import.meta.env.DEV
+      ? "http://localhost:5173" // 개발환경에서는 프록시 사용
+      : import.meta.env.VITE_API_BASE_URL || "http://13.209.252.181:8080";
+
+    // 쿼리 파라미터 구성
+    const queryParams = new URLSearchParams({
+      googleID: params.googleID,
+      page: (params.page ?? 0).toString(),
+      size: (params.size ?? 10).toString(),
+    });
+
+    console.log("🔗 작가 노트 리스트 API 호출");
+    const response = await axios.get<ArtistNoteApiResponse>(
+      `${baseURL}/api/artist_note/main?${queryParams.toString()}`,
+      {
+        headers: {
+          "Content-Type": "application/json",
+        },
+        timeout: 30000,
+      }
+    );
+
+    console.log("📦 작가 노트 리스트 백엔드 응답:", response.data);
+    console.log("📋 작가 노트 리스트 데이터:", response.data.data);
+    console.log("🎭 실제 content 배열:", response.data.data.content);
+
+    return response.data;
+  },
+};

--- a/src/apis/index.ts
+++ b/src/apis/index.ts
@@ -11,3 +11,9 @@ export {
   type CollectorRegistrationData,
   type GalleryRegistrationData,
 } from "./user";
+
+// 작가 노트 관련 API
+export { artistNoteApi } from "./artistNote";
+
+// 태그 관련 API
+export { tagApi } from "./tag";

--- a/src/apis/tag.ts
+++ b/src/apis/tag.ts
@@ -1,0 +1,31 @@
+import axios from "axios";
+import type { TagListApiResponse } from "../types/tag";
+
+// 태그 API 객체
+export const tagApi = {
+  // 태그 리스트 조회 API
+  async getTagList(): Promise<TagListApiResponse> {
+    console.log("🏷️ 태그 리스트 조회 시작");
+
+    // 인터셉터를 우회하여 직접 axios 사용
+    const baseURL = import.meta.env.DEV
+      ? "http://localhost:5173" // 개발환경에서는 프록시 사용
+      : import.meta.env.VITE_API_BASE_URL || "http://13.209.252.181:8080";
+
+    console.log("🔗 태그 리스트 API 호출");
+    const response = await axios.get<TagListApiResponse>(
+      `${baseURL}/api/tag/list`,
+      {
+        headers: {
+          "Content-Type": "application/json",
+        },
+        timeout: 30000,
+      }
+    );
+
+    console.log("📦 태그 리스트 백엔드 응답:", response.data);
+    console.log("📋 태그 리스트 데이터:", response.data.data);
+
+    return response.data;
+  },
+};

--- a/src/components/Layouts/Header.tsx
+++ b/src/components/Layouts/Header.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from "react";
 import { cn } from "../../utils/classname";
 import { Button } from "../Button";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useLocation } from "react-router-dom";
 import { useLogout, useSidebarProfile } from "../../hooks/useUser";
 
 interface HeaderProps {
@@ -12,6 +12,7 @@ const Header: React.FC<HeaderProps> = ({ className = "" }) => {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const [searchQuery, setSearchQuery] = useState("");
   const navigate = useNavigate();
+  const location = useLocation();
   const logoutMutation = useLogout();
 
   // Google ID 가져오기
@@ -54,6 +55,11 @@ const Header: React.FC<HeaderProps> = ({ className = "" }) => {
 
   const closeSidebar = () => {
     setIsMenuOpen(false);
+  };
+
+  // 현재 경로에 따른 active 상태 확인
+  const isActiveMenu = (path: string) => {
+    return location.pathname === path;
   };
 
   return (
@@ -104,25 +110,45 @@ const Header: React.FC<HeaderProps> = ({ className = "" }) => {
         <nav className="flex items-center gap-10 lg:gap-20 text-lg font-semibold">
           <button
             onClick={() => navigate("/note")}
-            className="cursor-pointer px-3 py-2 text-zinc-900 hover:text-red-500 transition-colors duration-200"
+            className={cn(
+              "cursor-pointer px-3 py-2 transition-colors duration-200",
+              isActiveMenu("/note")
+                ? "text-red-500"
+                : "text-zinc-900 hover:text-red-500"
+            )}
           >
             NOTE
           </button>
           <button
             onClick={() => navigate("/collection")}
-            className="cursor-pointer px-3 py-2 text-zinc-900 hover:text-red-500 transition-colors duration-200"
+            className={cn(
+              "cursor-pointer px-3 py-2 transition-colors duration-200",
+              isActiveMenu("/collection")
+                ? "text-red-500"
+                : "text-zinc-900 hover:text-red-500"
+            )}
           >
             COLLECTION
           </button>
           <button
             onClick={() => navigate("/exhibition")}
-            className="cursor-pointer px-3 py-2 text-zinc-900 hover:text-red-500 transition-colors duration-200"
+            className={cn(
+              "cursor-pointer px-3 py-2 transition-colors duration-200",
+              isActiveMenu("/exhibition")
+                ? "text-red-500"
+                : "text-zinc-900 hover:text-red-500"
+            )}
           >
             EXHIBITION
           </button>
           <button
             onClick={() => navigate("/contest")}
-            className="cursor-pointer px-3 py-2 text-zinc-900 hover:text-red-500 transition-colors duration-200"
+            className={cn(
+              "cursor-pointer px-3 py-2 transition-colors duration-200",
+              isActiveMenu("/contest")
+                ? "text-red-500"
+                : "text-zinc-900 hover:text-red-500"
+            )}
           >
             CONTEST
           </button>

--- a/src/hooks/useArtistNote.ts
+++ b/src/hooks/useArtistNote.ts
@@ -1,0 +1,27 @@
+import { useQuery } from "@tanstack/react-query";
+import { artistNoteApi } from "../apis/artistNote";
+import type {
+  ArtistNoteListParams,
+  ArtistNoteApiResponse,
+} from "../types/artistNote";
+
+// Query Keys 정의
+export const artistNoteKeys = {
+  all: ["artistNote"] as const,
+  lists: () => [...artistNoteKeys.all, "list"] as const,
+  list: (params: ArtistNoteListParams) =>
+    [...artistNoteKeys.lists(), params] as const,
+};
+
+// 작가 노트 리스트 조회 훅
+export const useArtistNoteList = (params: ArtistNoteListParams) => {
+  return useQuery<ArtistNoteApiResponse>({
+    queryKey: artistNoteKeys.list(params),
+    queryFn: () => artistNoteApi.getArtistNoteList(params),
+    enabled: !!params.googleID, // googleID가 있을 때만 쿼리 실행
+    staleTime: 5 * 60 * 1000, // 5분간 fresh 상태 유지
+    gcTime: 10 * 60 * 1000, // 10분간 가비지 컬렉션 방지
+    retry: 2, // 실패 시 2회 재시도
+    refetchOnWindowFocus: false, // 창 포커스 시 재호출 방지
+  });
+};

--- a/src/hooks/useTag.ts
+++ b/src/hooks/useTag.ts
@@ -1,0 +1,21 @@
+import { useQuery } from "@tanstack/react-query";
+import { tagApi } from "../apis/tag";
+import type { TagListApiResponse } from "../types/tag";
+
+// Query Keys 정의
+export const tagKeys = {
+  all: ["tag"] as const,
+  lists: () => [...tagKeys.all, "list"] as const,
+};
+
+// 태그 리스트 조회 훅
+export const useTagList = () => {
+  return useQuery<TagListApiResponse>({
+    queryKey: tagKeys.lists(),
+    queryFn: () => tagApi.getTagList(),
+    staleTime: 30 * 60 * 1000, // 30분간 fresh 상태 유지 (태그는 자주 변경되지 않음)
+    gcTime: 60 * 60 * 1000, // 1시간간 가비지 컬렉션 방지
+    retry: 2, // 실패 시 2회 재시도
+    refetchOnWindowFocus: false, // 창 포커스 시 재호출 방지
+  });
+};

--- a/src/pages/ArtistNotePage.tsx
+++ b/src/pages/ArtistNotePage.tsx
@@ -1,90 +1,14 @@
-import { useState } from "react";
+import { useState, useMemo } from "react";
 import { Header } from "../components";
 import Chip from "../components/Chip";
 import BannerControl from "../components/Profile/BannerControl";
 import ProfileCard from "../components/Profile/ProfileCard";
 import { useNavigate } from "react-router-dom";
+import { useArtistNoteList } from "../hooks/useArtistNote";
+import { useTagList } from "../hooks/useTag";
+import type { ArtistNote } from "../types/artistNote";
 
-const categories = [
-  "전체",
-  "회화",
-  "조각",
-  "공예",
-  "건축",
-  "사진",
-  "미디어아트",
-  "인테리어",
-  "기타",
-] as const;
-type Category = (typeof categories)[number];
-
-const mockData = [
-  {
-    id: "1",
-    role: "작가",
-    nickName: "닉네임",
-    phoneNumber: "010-1234-5678",
-    email: "test@test.com",
-    introduction:
-      "전통 수묵의 깊이와 현대미술의 자유로움이 만나, 새로운 숨결을 그려냅니다.",
-    isMyProfile: false,
-    category: "회화",
-  },
-  {
-    id: "2",
-    role: "작가",
-    nickName: "닉네임",
-    phoneNumber: "010-1234-5678",
-    email: "test@test.com",
-    introduction: "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
-    category: "조각",
-  },
-  {
-    id: "3",
-    role: "작가",
-    nickName: "닉네임",
-    phoneNumber: "010-1234-5678",
-    email: "test@test.com",
-    introduction: "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
-    category: "공예",
-  },
-  {
-    id: "4",
-    role: "작가",
-    nickName: "닉네임",
-    phoneNumber: "010-1234-5678",
-    email: "test@test.com",
-    introduction: "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
-    category: "회화",
-  },
-  {
-    id: "5",
-    role: "작가",
-    nickName: "닉네임",
-    phoneNumber: "010-1234-5678",
-    email: "test@test.com",
-    introduction: "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
-    category: "사진",
-  },
-  {
-    id: "6",
-    role: "작가",
-    nickName: "닉네임",
-    phoneNumber: "010-1234-5678",
-    email: "test@test.com",
-    introduction: "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
-    category: "미디어아트",
-  },
-  {
-    id: "7",
-    role: "작가",
-    nickName: "닉네임",
-    phoneNumber: "010-1234-5678",
-    email: "test@test.com",
-    introduction: "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
-    category: "인테리어",
-  },
-];
+type Category = "전체" | string;
 
 const ArtistNotePage = () => {
   const navigate = useNavigate();
@@ -95,11 +19,60 @@ const ArtistNotePage = () => {
 
   const [selectedCategory, setSelectedCategory] = useState<Category>("전체");
 
-  // 선택된 카테고리에 따라 작가 데이터 필터링
-  const filteredData =
-    selectedCategory === "전체"
-      ? mockData
-      : mockData.filter((artist) => artist.category === selectedCategory);
+  // 현재 로그인한 사용자의 googleID 가져오기
+  const googleID = localStorage.getItem("googleID") || "";
+
+  // 태그 리스트 조회
+  const { data: tagResponse } = useTagList();
+
+  // 작가 노트 리스트 조회
+  const {
+    data: artistNoteResponse,
+    isLoading,
+    error,
+  } = useArtistNoteList({
+    googleID,
+    page: 0,
+    size: 100, // 모든 데이터를 가져오기 위해 큰 수로 설정
+  });
+
+  // 동적으로 가져온 태그를 포함한 카테고리 목록 생성
+  const categories = useMemo(() => {
+    if (!tagResponse?.data) {
+      return ["전체"]; // 태그 로딩 중이거나 실패한 경우 기본값
+    }
+    return ["전체", ...tagResponse.data.map((tag) => tag.name)];
+  }, [tagResponse]);
+
+  // API 데이터를 기존 mockData 형식으로 변환하고 카테고리 필터링
+  const filteredData = useMemo(() => {
+    if (!artistNoteResponse?.data?.content) {
+      return [];
+    }
+
+    // API 데이터를 기존 mockData 형식으로 변환
+    const transformedData = artistNoteResponse.data.content.map(
+      (artist: ArtistNote) => ({
+        id: artist.id.toString(),
+        role: "작가" as const,
+        nickName: artist.name,
+        phoneNumber: artist.contact,
+        email: artist.email,
+        introduction: artist.introduction,
+        isMyProfile: artist.isMine,
+        category: "전체" as Category, // API에서 카테고리 정보가 없으므로 기본값 설정
+      })
+    );
+
+    // 선택된 카테고리에 따라 필터링 (현재는 카테고리 정보가 없으므로 모든 데이터 반환)
+    if (selectedCategory === "전체") {
+      return transformedData;
+    }
+
+    // 실제 카테고리 필드가 API에 추가되면 다음과 같이 필터링
+    // return transformedData.filter((artist) => artist.category === selectedCategory);
+    return transformedData;
+  }, [artistNoteResponse, selectedCategory]);
 
   return (
     <div className="min-h-screen bg-white">
@@ -113,11 +86,27 @@ const ArtistNotePage = () => {
               label={category}
               isActive={selectedCategory === category}
               onClick={() => setSelectedCategory(category)}
+              className="text-nowrap"
             />
           ))}
         </div>
         <div className="grid grid-cols-2 gap-x-20">
-          {filteredData.length === 0 ? (
+          {isLoading ? (
+            <div className="col-span-2 text-center mt-24 text-gray-500 text-lg">
+              작가 노트를 불러오는 중...
+            </div>
+          ) : error ? (
+            <div className="col-span-2 text-center mt-24 text-red-500 text-lg">
+              작가 노트를 불러오는데 실패했습니다.
+              <br />
+              <button
+                onClick={() => window.location.reload()}
+                className="mt-4 px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-600"
+              >
+                다시 시도
+              </button>
+            </div>
+          ) : filteredData.length === 0 ? (
             <div className="col-span-2 text-center mt-24 text-gray-500 text-lg">
               아직 업로드된 작가 포트폴리오가 없습니다.
             </div>

--- a/src/pages/CollectionPage.tsx
+++ b/src/pages/CollectionPage.tsx
@@ -5,21 +5,11 @@ import Chip from "../components/Chip";
 import Header from "../components/Layouts/Header";
 import BannerControl from "../components/Profile/BannerControl";
 import EmptyState from "../components/EmptyState";
+import { useTagList } from "../hooks/useTag";
 
 // 빈 상태 이미지
 
-const categories = [
-  "전체",
-  "회화",
-  "조각",
-  "공예",
-  "건축",
-  "사진",
-  "미디어아트",
-  "인테리어",
-  "기타",
-] as const;
-type Category = (typeof categories)[number];
+type Category = "전체" | string;
 
 type Artwork = {
   imageUrl: string;
@@ -71,6 +61,17 @@ const artworks: Artwork[] = [
 
 const CollectionPage: React.FC = () => {
   const [selectedCategory, setSelectedCategory] = useState<Category>("전체");
+
+  // 태그 리스트 조회
+  const { data: tagResponse } = useTagList();
+
+  // 동적으로 가져온 태그를 포함한 카테고리 목록 생성
+  const categories = useMemo(() => {
+    if (!tagResponse?.data) {
+      return ["전체"]; // 태그 로딩 중이거나 실패한 경우 기본값
+    }
+    return ["전체", ...tagResponse.data.map((tag) => tag.name)];
+  }, [tagResponse]);
 
   const filteredArtworks = useMemo(() => {
     return selectedCategory === "전체"

--- a/src/pages/ContestPage.tsx
+++ b/src/pages/ContestPage.tsx
@@ -5,21 +5,11 @@ import Chip from "../components/Chip";
 import Header from "../components/Layouts/Header";
 import BannerControl from "../components/Profile/BannerControl";
 import EmptyState from "../components/EmptyState";
+import { useTagList } from "../hooks/useTag";
 
 // 빈 상태 이미지
 
-const categories = [
-  "전체",
-  "회화",
-  "조각",
-  "공예",
-  "건축",
-  "사진",
-  "미디어아트",
-  "인테리어",
-  "기타",
-] as const;
-type Category = (typeof categories)[number];
+type Category = "전체" | string;
 
 type Contest = {
   imageUrl: string;
@@ -50,6 +40,17 @@ const contests: Contest[] = [
 
 const ContestPage: React.FC = () => {
   const [selectedCategory, setSelectedCategory] = useState<Category>("전체");
+
+  // 태그 리스트 조회
+  const { data: tagResponse } = useTagList();
+
+  // 동적으로 가져온 태그를 포함한 카테고리 목록 생성
+  const categories = useMemo(() => {
+    if (!tagResponse?.data) {
+      return ["전체"]; // 태그 로딩 중이거나 실패한 경우 기본값
+    }
+    return ["전체", ...tagResponse.data.map((tag) => tag.name)];
+  }, [tagResponse]);
 
   const filteredContests = useMemo(() => {
     return selectedCategory === "전체"

--- a/src/pages/ExhibitionPage.tsx
+++ b/src/pages/ExhibitionPage.tsx
@@ -5,21 +5,11 @@ import Chip from "../components/Chip";
 import Header from "../components/Layouts/Header";
 import BannerControl from "../components/Profile/BannerControl";
 import EmptyState from "../components/EmptyState";
+import { useTagList } from "../hooks/useTag";
 
 // 빈 상태 이미지
 
-const categories = [
-  "전체",
-  "회화",
-  "조각",
-  "공예",
-  "건축",
-  "사진",
-  "미디어아트",
-  "인테리어",
-  "기타",
-] as const;
-type Category = (typeof categories)[number];
+type Category = "전체" | string;
 
 type Exhibition = {
   imageUrl: string;
@@ -45,6 +35,17 @@ const exhibitions: Exhibition[] = [
 
 const ExhibitionPage: React.FC = () => {
   const [selectedCategory, setSelectedCategory] = useState<Category>("전체");
+
+  // 태그 리스트 조회
+  const { data: tagResponse } = useTagList();
+
+  // 동적으로 가져온 태그를 포함한 카테고리 목록 생성
+  const categories = useMemo(() => {
+    if (!tagResponse?.data) {
+      return ["전체"]; // 태그 로딩 중이거나 실패한 경우 기본값
+    }
+    return ["전체", ...tagResponse.data.map((tag) => tag.name)];
+  }, [tagResponse]);
 
   const filtered = useMemo(() => {
     return selectedCategory === "전체"

--- a/src/pages/SearchResultPage.tsx
+++ b/src/pages/SearchResultPage.tsx
@@ -1,48 +1,14 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useMemo } from "react";
 import { useSearchParams } from "react-router-dom";
 import { Button, Header } from "../components";
 import TabMenu from "../components/Profile/TabMenu";
 import ArtworkCard from "../components/ArtworkCard";
 import Chip from "../components/Chip";
+import { useTagList } from "../hooks/useTag";
 
-// 탭별 카테고리 정의
-const categories = {
-  artworkCollection: [
-    "전체",
-    "회화",
-    "조각",
-    "공예",
-    "건축",
-    "사진",
-    "미디어아트",
-    "인테리어",
-    "기타",
-  ],
-  exhibition: [
-    "전체",
-    "회화",
-    "조각",
-    "공예",
-    "건축",
-    "사진",
-    "미디어아트",
-    "인테리어",
-    "기타",
-  ],
-  contest: [
-    "전체",
-    "회화",
-    "조각",
-    "공예",
-    "건축",
-    "사진",
-    "미디어아트",
-    "인테리어",
-    "기타",
-  ],
-} as const;
+// 탭별 카테고리 정의 (동적으로 생성됨)
 
-type TabId = keyof typeof categories;
+type TabId = "artworkCollection" | "exhibition" | "contest";
 type Category = string;
 
 // 타입 정의
@@ -104,6 +70,30 @@ const SearchResultPage = () => {
   const [selectedTabId, setSelectedTabId] =
     useState<TabId>("artworkCollection");
   const [selectedCategory, setSelectedCategory] = useState<Category>("전체");
+
+  // 태그 리스트 조회
+  const { data: tagResponse } = useTagList();
+
+  // 동적으로 가져온 태그를 포함한 카테고리 목록 생성
+  const categories = useMemo(() => {
+    const defaultCategories = ["전체"];
+    if (!tagResponse?.data) {
+      return {
+        artworkCollection: defaultCategories,
+        exhibition: defaultCategories,
+        contest: defaultCategories,
+      };
+    }
+    const dynamicCategories = [
+      "전체",
+      ...tagResponse.data.map((tag) => tag.name),
+    ];
+    return {
+      artworkCollection: dynamicCategories,
+      exhibition: dynamicCategories,
+      contest: dynamicCategories,
+    };
+  }, [tagResponse]);
 
   // URL 파라미터에서 검색어 가져오기
   useEffect(() => {

--- a/src/types/artistNote.ts
+++ b/src/types/artistNote.ts
@@ -1,0 +1,53 @@
+// 작가 노트 관련 타입 정의
+
+export interface ArtistNote {
+  id: number;
+  name: string;
+  contact: string;
+  introduction: string;
+  email: string;
+  profileImageURL: string;
+  isMine: boolean;
+}
+
+export interface Sort {
+  sorted: boolean;
+  empty: boolean;
+  unsorted: boolean;
+}
+
+export interface Pageable {
+  pageNumber: number;
+  pageSize: number;
+  offset: number;
+  sort: Sort;
+  paged: boolean;
+  unpaged: boolean;
+}
+
+export interface ArtistNoteListResponse {
+  totalPages: number;
+  totalElements: number;
+  pageable: Pageable;
+  first: boolean;
+  last: boolean;
+  size: number;
+  content: ArtistNote[];
+  number: number;
+  sort: Sort;
+  numberOfElements: number;
+  empty: boolean;
+}
+
+export interface ArtistNoteApiResponse {
+  code: number;
+  status: string;
+  message: string;
+  data: ArtistNoteListResponse;
+}
+
+export interface ArtistNoteListParams {
+  page?: number;
+  size?: number;
+  googleID: string;
+}

--- a/src/types/tag.ts
+++ b/src/types/tag.ts
@@ -1,0 +1,13 @@
+// 태그 관련 타입 정의
+
+export interface Tag {
+  id: number;
+  name: string;
+}
+
+export interface TagListApiResponse {
+  code: number;
+  status: string;
+  message: string;
+  data: Tag[];
+}


### PR DESCRIPTION
- package.json에 Vercel 및 Netlify 배포 스크립트 추가
- artistNote API 및 tag API를 index.ts에 추가하여 관련 기능 구현
- Header 컴포넌트에서 현재 경로에 따른 활성 메뉴 상태 확인 기능 추가
- ArtistNotePage에서 API를 통해 작가 노트 리스트를 동적으로 가져오도록 수정
- CollectionPage, ContestPage, ExhibitionPage, SearchResultPage에서 태그 리스트를 동적으로 가져오도록 개선

[🎯가이드라인 준수: 한국어 응답, 에이전트 역할 명시, 작업 수행 알림]

### 📌 PR 제목 (제목 작성 후 해당 부분은 내용에서 지워주세요!)

[Feat/#이슈 번호] " pr message "
(예시 : [Feat/#1] "로그인 기능 추가")   

### 📌 관련 이슈번호

(Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힌다)

- Closes #이슈 번호

### 📌 PR 유형

어떤 변경 사항이 있나요?

- [ ] 새 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 리팩토링

### 📌 PR 요약

해당 PR을 간단하게 요약해 주세요

### 📌 작업 세부 내용

1.
2.
3.

### 📸 스크린샷 (선택)

### 🔗 참고 자료

​
